### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,7 +4,7 @@ author=gmag11
 maintainer=gmag11
 sentence=Firmata client (master) library for ESP8266 (or any other Arduino compatible board)
 paragraph=
-category=Device
+category=Device Control
 url=https://github.com/gmag11/FirmataMaster
 architectures=*
 


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Device' in library FirmataMaster is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format